### PR TITLE
Implement _pre/postRelayedCall in Counter.sol

### DIFF
--- a/contracts/Counter.sol
+++ b/contracts/Counter.sol
@@ -28,6 +28,12 @@ contract Counter is Initializable, GSNRecipient {
     ) external view returns (uint256, bytes memory) {
     return _approveRelayedCall();
   }
+  
+  function _preRelayedCall(bytes memory context) internal returns (bytes32) {
+  }
+
+  function _postRelayedCall(bytes memory context, bool, uint256 actualCharge, bytes32) internal {
+  }
 
   function owner() public view returns (address) {
     return _owner;


### PR DESCRIPTION
`@openzeppelin/contracts-ethereum-package/contracts/GSN/GSNRecipient.sol` doesn't implement `_preRelayedCall` and `_postRelayedCall` so cannot `oz create` Counter as it is abstract without these implementations.